### PR TITLE
Fixed the title of "Cover" column

### DIFF
--- a/resources/books/books_1.md
+++ b/resources/books/books_1.md
@@ -3,7 +3,7 @@
 <table>
 	<thead>
 		<tr>
-			<th>Covers(F(,B))</th>
+			<th>Cover</th>
 			<th>Title, Year, ISBN</th>
 			<th>Description</th>
 			<th>Authors</th>
@@ -52,7 +52,7 @@
 <table>
 	<thead>
 		<tr>
-			<th>Covers(F(,B))</th>
+			<th>Cover</th>
 			<th>Title, Year, ISBN</th>
 			<th>Description</th>
 			<th>Authors</th>


### PR DESCRIPTION
Initially, the idea was to include front and back covers(where the second was optional, thus, the parents `(`, `)`), but back ones are hard to find and might use too much space in such table, though.