### PR TITLE
Added markdown formatted links to GitHub and Discord on Projects page.

### DIFF
--- a/community/projects/projects_1.md
+++ b/community/projects/projects_1.md
@@ -4,112 +4,112 @@ Follow the template of:
 ```
 ## Project name
 Description: A free-to-play match-three puzzle video game for all mobile devices  
-Repo link: https://github.com/github/hub  
+Repo link: [https://github.com/github/hub](https://github.com/github/hub)  
 Author: discord link or email or github name  
 ```
 
 ## Xacor
 Description: Experimental Game Engine  
-Git link: https://github.com/deccer/Xacor  
-Author: @deccer#1371  
+Git link: [https://github.com/deccer/Xacor](https://github.com/deccer/Xacor)  
+Author: [@deccer#1371](https://discordapp.com/channels/@me/194502965749350400/)  
 
 ## Documentation Templater
 Description: Cross-platform Templating Engine for Quickly and Easily Creating Static Web-Based Documentation Projects in HTML and Markdown.  
-repo: https://github.com/James231/Documentation-Templater  
-author: @JamEs#8187  
+repo: [https://github.com/James231/Documentation-Templater](https://github.com/James231/Documentation-Templater)  
+author: [Discord: @JamEs#8187](https://discordapp.com/channels/@me/694233917661773864/), [GitHub: James231](https://github.com/James231)  
 
 ## FahStats
 Description: Get Statistics from Folding@Home right at your fingertips or even implement into a .NET Discord Bot for your members.  
-Repo link: https://github.com/Blizzardo1/FahStats  
-Author: @GeneralKenobi#0001  
+Repo link: [https://github.com/Blizzardo1/FahStats](https://github.com/Blizzardo1/FahStats)  
+Author: [@GeneralKenobi#0001](https://discordapp.com/channels/@me/678488422280724491/)  
 
 ## Riftworks
 Description: A multi-faceted social media interface  
-Repo link: https://github.com/skylerspaeth/Rift  
-Author: @SHODAN#5505  
+Repo link: [https://github.com/skylerspaeth/Rift](https://github.com/skylerspaeth/Rift)  
+Author: [@SHODAN#5505](https://discordapp.com/channels/@me/716549941975056446/)  
 
 ## x42 Protocol
 Description: A Feeless Cryptocurrency which uses C# as the coding language.The x42 Blockchain  
 allows for the creation, distribution and decentralized hosting of applications.The smart contracts in x42 use C# which make them easy to develop, test and debug.  
-Repo link: https://github.com/x42protocol  
-Author: @\/ikhyath#8139  
+Repo link: [https://github.com/x42protocol](https://github.com/x42protocol)  
+Author: [@\/ikhyath#8139](https://discordapp.com/channels/@me/497454379058855973/)  
 
 ## Analytix
 Description: The main bot for this discord server. Will process commands for various things and also keep track of analytical data for admin usage.  
-Repository: https://github.com/reikotechnology/projekt-analytix  
-Author: @Miss Anthrxpic#6477  
+Repository: [https://github.com/reikotechnology/projekt-analytix](https://github.com/reikotechnology/projekt-analytix)  
+Author: [@Miss Anthrxpic#6477](https://discordapp.com/channels/@me/679521537484652733/)  
 
 ## Didactical Enigma
-Description: An integrated translator environment for translating text from Japanese to English. 
-Segments sentences into words, provides information about characters, including kanji decomposition into components, 
-looks up word definitions in a dictionary, looks up example sentences, conjugates and deconjugates verbs, allows for custom notes, 
+Description: An integrated translator environment for translating text from Japanese to English.  
+Segments sentences into words, provides information about characters, including kanji decomposition into components,  
+looks up word definitions in a dictionary, looks up example sentences, conjugates and deconjugates verbs, allows for custom notes,  
 allows for kanji lookup by components, provides hiragana and katakana cheat sheets. Currently a WPF application, Avalonia port is planned in the future.  
-Repo link: https://github.com/milleniumbug/DidacticalEnigma  
-Author: @milleniumbug#6545  
+Repo link: [https://github.com/milleniumbug/DidacticalEnigma](https://github.com/milleniumbug/DidacticalEnigma)  
+Author: [@milleniumbug#6545](https://discordapp.com/channels/@me/651538987022024726/)  
 
 ## Student management system
 Description: https://studentmanagementrp.azurewebsites.net/.  
-Repo link: https://github.com/RPickering327/StudentManagementASP  
-Author: @RIchard#5172  
+Repo link: [https://github.com/RPickering327/StudentManagementASP](https://github.com/RPickering327/StudentManagementASP)  
+Author: [@RIchard#5172](https://discordapp.com/channels/@me/560521457214423050/)  
 
 ## BookKeeper
 Description: (WIP) Simple WPF application to keep track of books user has read as well as a wishlist and search functionality.  
-Repo link: https://github.com/KarimShavar/BookKeep  
-Author: @Karim#2521  
+Repo link: [https://github.com/KarimShavar/BookKeep](https://github.com/KarimShavar/BookKeep)  
+Author: [@Karim#2521](https://discordapp.com/channels/@me/678684655934898209/)  
 
 ## FrEee
 Description: Open source clone of the classic 4X game Space Empires IV  
-Repo link: https://bitbucket.org/ekolis/freee/src  
-Author: @ekolis#7039  
+Repo link: [https://bitbucket.org/ekolis/freee/src](https://bitbucket.org/ekolis/freee/src)  
+Author: [@ekolis#7039](https://discordapp.com/channels/@me/720002757439782984/)  
 
 ## StringDB
 Description: StringDB is a modular, fluent, and understandable archival key/value pair DB.  
-Repo link: https://github.com/SirJosh3917/StringDB  
-Author: @SirJosh#3917  
+Repo link: [https://github.com/SirJosh3917/StringDB](https://github.com/SirJosh3917/StringDB)  
+Author: [@SirJosh#3917](https://discordapp.com/channels/@me/651730601946382356/)  
 
 ## TypeSmash
 Description: A typing game among players to see who can type the fastest.  
-Repo link: https://github.com/nosyminotaur/TypeSmash  
-Author: @nosyminotaur#7241  
+Repo link: [https://github.com/nosyminotaur/TypeSmash](https://github.com/nosyminotaur/TypeSmash)  
+Author: [@nosyminotaur#7241](https://discordapp.com/channels/@me/609972280596103199/)  
 
 ## Gremmer
 Description: Open-source bookkeeping software  
-Repo link: https://github.com/caveofjulian/Gremmer  
-Author: @mhmmmmmmm#7990  
+Repo link: [https://github.com/caveofjulian/Gremmer](https://github.com/caveofjulian/Gremmer)  
+Author: [@mhmmmmmmm#7990](https://discordapp.com/channels/@me/573584580712595486/)  
 
 ## Empa
 Description: An AI being made with empathy, sympathy, compassion, generosity, kindness, love, care, and more, so that she will help others.  
 She will be a doctor, with all the knowledge required, so that she will be able to do so efficiently.  
-Repo link: https://github.com/alex-sour/empa  
-Subreddit: https://empa.reddit.com/  
-Author: Alex_Sour#8083  
+Repo link: [https://github.com/alex-sour/empa](https://github.com/alex-sour/empa)  
+Subreddit: [https://empa.reddit.com/](https://empa.reddit.com/)  
+Author: [@Alex_Sour#8083](https://discordapp.com/channels/@me/715564793867796530/)  
 
 ## PathHinter
 Description: This project reimplements the behaviour for autocompleting paths from a Unix terminal.  
-Repo link: https://github.com/uta-org/PathHinter  
-Author: @z3nth10n#0775  
+Repo link: [https://github.com/uta-org/PathHinter](https://github.com/uta-org/PathHinter)  
+Author: [@z3nth10n#0775](https://discordapp.com/channels/@me/723351760328065086/)  
 
 ## Goodwitch
 Description: Goodwitch is an anti-cheat written in C# which supports traditional and modern usermode(ring3) 
 anti-cheat features from process and debugger detection to detection of memory manipulations.  
-Repo link: https://github.com/ZeroLP/Goodwitch  
-Author: @admiralzero#6142  
+Repo link: [https://github.com/ZeroLP/Goodwitch](https://github.com/ZeroLP/Goodwitch)  
+Author: [@admiralzero#6142](https://discordapp.com/channels/@me/655406221561430016/)  
 
 ## RealmOfEverlastingCode/CSharp
 Description: solutions to common software design problems.  
-Repo link: https://github.com/Realm-of-Everlasting-Code/C-Sharp  
-Author: @Kaisinel#4921  
+Repo link: [https://github.com/Realm-of-Everlasting-Code/C-Sharp](https://github.com/Realm-of-Everlasting-Code/C-Sharp)  
+Author: [@Kaisinel#4921](https://discordapp.com/channels/@me/184398227368443904/)  
 
 ## SQL Wrappers
-Author: @kuro-#1016
+Author: [@kuro-#1016](https://discordapp.com/channels/@me/682076410202030100/)  
 ### POCO Mapper
 Description: An alternative "Plain Old C# Objects" mapper with minimal configuration required.  
-Repo link: https://kuromukira.github.io/poco.mapper/  
+Repo link: [https://kuromukira.github.io/poco.mapper/](https://kuromukira.github.io/poco.mapper/)  
 
 ### LiteDB Wrapper
 Description: A simpler way to use LiteDB.  
-Repo link: https://kuromukira.github.io/LiteDB.Wrapper  
+Repo link: [https://kuromukira.github.io/LiteDB.Wrapper](https://kuromukira.github.io/LiteDB.Wrapper)  
 
 ### Azure Functions Custom Jwt Handler
 Description: A custom access token validation provider for Azure Functions via Dependency Injection  
-Repo link: https://github.com/kuromukira/azure-functions-jwt-validation-extension  
+Repo link: [https://github.com/kuromukira/azure-functions-jwt-validation-extension](https://github.com/kuromukira/azure-functions-jwt-validation-extension)  


### PR DESCRIPTION
On the projects page, i've added the correct formatting so the links work in markdown.

I've done this for all GitHub links and all Discord users.

For discord, the link should take you to a DM with the user (took me a while to find all those user ids :)